### PR TITLE
Add build for our fork of cql translation repo

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,19 @@
+name: Publish package to GitHub Packages
+on:
+  push:
+    branches:
+      - master
+  release:
+    types: [created]
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-java@v1
+        with:
+          java-version: 1.8
+      - name: Publish package
+        run: mvn -B deploy
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/pom.xml
+++ b/pom.xml
@@ -3,11 +3,11 @@
 
   <modelVersion>4.0.0</modelVersion>
 
-  <groupId>org.mitre.bonnie</groupId>
-  <artifactId>cqlTranslationServer</artifactId>
+  <groupId>com.ibm.cohort</groupId>
+  <artifactId>cql-translation-server</artifactId>
   <packaging>jar</packaging>
-  <version>1.4.9</version>
-  <name>cqlTranslationServer</name>
+  <version>${cqframework.version}</version>
+  <name>cql-translation-server</name>
 
   <repositories>
     <repository>
@@ -70,32 +70,32 @@
     <dependency>
       <groupId>info.cqframework</groupId>
       <artifactId>cql</artifactId>
-      <version>1.4.9</version>
+      <version>${cqframework.version}</version>
     </dependency>
     <dependency>
       <groupId>info.cqframework</groupId>
       <artifactId>model</artifactId>
-      <version>1.4.9</version>
+      <version>${cqframework.version}</version>
     </dependency>
     <dependency>
       <groupId>info.cqframework</groupId>
       <artifactId>cql-to-elm</artifactId>
-      <version>1.4.9</version>
+      <version>${cqframework.version}</version>
     </dependency>
     <dependency>
       <groupId>info.cqframework</groupId>
       <artifactId>elm</artifactId>
-      <version>1.4.9</version>
+      <version>${cqframework.version}</version>
     </dependency>
     <dependency>
       <groupId>info.cqframework</groupId>
       <artifactId>quick</artifactId>
-      <version>1.4.9</version>
+      <version>${cqframework.version}</version>
     </dependency>
     <dependency>
-		  <groupId>info.cqframework</groupId>
-		  <artifactId>qdm</artifactId>
-		  <version>1.4.9</version>
+      <groupId>info.cqframework</groupId>
+      <artifactId>qdm</artifactId>
+      <version>${cqframework.version}</version>
     </dependency>
     <dependency>
       <groupId>commons-cli</groupId>
@@ -160,5 +160,14 @@
   <properties>
     <jersey.version>2.32</jersey.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <cqframework.version>1.5.1-SNAPSHOT</cqframework.version>
   </properties>
+
+  <distributionManagement>
+    <repository>
+      <id>github</id>
+      <name>GitHub Packages</name>
+      <url>https://maven.pkg.github.com/Alvearie/cql-translation-service</url>
+    </repository>
+  </distributionManagement>
 </project>


### PR DESCRIPTION
I wasn't sure what to do for `info.cqframework` dependencies since  we are tracking SNAPSHOTs at the moment in our main project. Let me know if you  would rather have me list a  non-shapshot version here.

I also had to change  the artifact id since camel-case was not playing nicely with publishing to github.